### PR TITLE
chore: add `directory` to package.json `repository` property

### DIFF
--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -58,7 +58,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Esri/calcite-design-system.git"
+    "url": "git+https://github.com/Esri/calcite-design-system.git",
+    "directory": "packages/calcite-components"
   },
   "dependencies": {
     "@floating-ui/dom": "1.5.1",


### PR DESCRIPTION
**Related Issue:** #

## Summary

This allows `npm repo @esri/calcite-components` to open directly to https://github.com/Esri/calcite-design-system/tree/main/packages/calcite-components

Reference: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository

Example: https://github.com/rollup/plugins/blob/a01a075364901c416db7485164613806187f6243/packages/commonjs/package.json#L11
